### PR TITLE
Standalone: Multi Loaders Support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <MaxCpuCount>0</MaxCpuCount>
+  </PropertyGroup>
+</Project>

--- a/Iridium.sln
+++ b/Iridium.sln
@@ -1,4 +1,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Iridium.Loader.UMM", "loaders\ummloader\Iridium.Loader.UMM.csproj", "{C9C9149D-3E64-4A9A-8D37-BDEBEDAB3CD6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Iridium.Loader.Melon", "loaders\melonloader\Iridium.Loader.Melon.csproj", "{71F4D5DC-16AA-4812-88BE-76EA03A1D4B1}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Iridium (v2.9.8)", "main\Iridium.csproj", "{3068C9C7-86F1-4F84-ADAA-A94291B7B28F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Iridium (v2.10.0)", "frontline\Iridium_frontline.csproj", "{8BD24856-6072-43F4-AAC1-D9DF48584677}"
@@ -9,6 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C9C9149D-3E64-4A9A-8D37-BDEBEDAB3CD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9C9149D-3E64-4A9A-8D37-BDEBEDAB3CD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9C9149D-3E64-4A9A-8D37-BDEBEDAB3CD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9C9149D-3E64-4A9A-8D37-BDEBEDAB3CD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71F4D5DC-16AA-4812-88BE-76EA03A1D4B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71F4D5DC-16AA-4812-88BE-76EA03A1D4B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71F4D5DC-16AA-4812-88BE-76EA03A1D4B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71F4D5DC-16AA-4812-88BE-76EA03A1D4B1}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3068C9C7-86F1-4F84-ADAA-A94291B7B28F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3068C9C7-86F1-4F84-ADAA-A94291B7B28F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3068C9C7-86F1-4F84-ADAA-A94291B7B28F}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/frontline/Config/SubSettings.cs
+++ b/frontline/Config/SubSettings.cs
@@ -68,6 +68,7 @@ namespace Iridium.Config
         public bool rangeBasedRedraw = false;              // 范围式重绘(Holds/Planets/Nums)
         public bool skipRedundantRemakePath = false;       // 跳过重复的RemakePath调用
         public bool optimizeOffsetFloorEvents = false;     // 优化 OffsetFloorIDsInEvents
+        public bool skipApplyEventsOnInsert = false;       // 增量插入时跳过 ApplyEventsToFloors
     }
 
     public class UISettings

--- a/frontline/Iridium_frontline.csproj
+++ b/frontline/Iridium_frontline.csproj
@@ -285,9 +285,10 @@
 		<Reference Include="UnityEngine.XRModule">
 			<HintPath>..\lib\v2.9.8\UnityEngine.XRModule.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityModManager">
-			<HintPath>..\lib\ModManager\UnityModManager.dll</HintPath>
-		</Reference>
+		<Reference Include="Microsoft.CSharp" />
+		<ProjectReference Include="..\loaders\ummloader\Iridium.Loader.UMM.csproj">
+			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="Info.json">
@@ -308,6 +309,7 @@
 		<MakeDir Directories="$(OutDir)Resources" />
 		<ItemGroup>
 			<FilesToCopy Include="$(OutputPath)$(AssemblyName).dll" />
+			<FilesToCopy Include="$(ProjectDir)..\bin\loaders\umm\net481\Iridium.Loader.UMM.dll" />
 			<FilesToCopy Include="$(ProjectDir)Info.json" />
 			<ResourceFiles Include="$(ProjectDir)Resources\**\*" Exclude="$(ProjectDir)Resources\**\*\" />
 		</ItemGroup>

--- a/frontline/Iridium_frontline.csproj
+++ b/frontline/Iridium_frontline.csproj
@@ -310,6 +310,7 @@
 		<ItemGroup>
 			<FilesToCopy Include="$(OutputPath)$(AssemblyName).dll" />
 			<FilesToCopy Include="$(ProjectDir)..\bin\loaders\umm\net481\Iridium.Loader.UMM.dll" />
+			<FilesToCopy Include="$(ProjectDir)..\bin\loaders\melon\net481\Iridium.Loader.Melon.dll" />
 			<FilesToCopy Include="$(ProjectDir)Info.json" />
 			<ResourceFiles Include="$(ProjectDir)Resources\**\*" Exclude="$(ProjectDir)Resources\**\*\" />
 		</ItemGroup>

--- a/frontline/Iridium_frontline.csproj
+++ b/frontline/Iridium_frontline.csproj
@@ -285,7 +285,6 @@
 		<Reference Include="UnityEngine.XRModule">
 			<HintPath>..\lib\v2.9.8\UnityEngine.XRModule.dll</HintPath>
 		</Reference>
-		<Reference Include="Microsoft.CSharp" />
 		<ProjectReference Include="..\loaders\ummloader\Iridium.Loader.UMM.csproj">
 			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
 		</ProjectReference>

--- a/frontline/Logger.cs
+++ b/frontline/Logger.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using UnityModManagerNet;
 
 
 namespace Iridium
@@ -36,13 +35,8 @@ namespace Iridium
         private const string MODNAME_ERROR = "[Iridium/ERROR] "; // Prefix Name
         private static readonly ConcurrentQueue<LogData> _writeQueue = new();
         private static Task? _task;
-        private static readonly List<string> _history = (List<string>)
-                typeof(UnityModManager.Logger).GetField("history", HarmonyLib.AccessTools.all).GetValue(null);
-        private static readonly int _historyCapacity = (int)
-                typeof(UnityModManager.Logger).GetField("historyCapacity", HarmonyLib.AccessTools.all).GetValue(null);
-        // 不写入buffer 减少性能消耗 (因为这玩意tm是主线程做IO写入的)
-        // private static unsafe readonly List<string> _buffer = (List<string>)
-        //         typeof(UnityModManager.Logger).GetField("buffer", HarmonyLib.AccessTools.all).GetValue(null);
+        private static readonly List<string> _history = new();
+        private const int _historyCapacity = 500;
 #if UNSAFE_MODE
         public static void TaskRun()
         {
@@ -142,8 +136,6 @@ namespace Iridium
 
 #endif
 
-        private readonly UnityModManager.ModEntry.ModLogger _logger;
-
         // 定义颜色常量
         private const string COLOR_RESET = "</color>";
         private const string COLOR_KEYWORD = "<color=#569CD6>"; // 例如：class, struct
@@ -163,10 +155,7 @@ namespace Iridium
         private const int MAX_ARRAY_ELEMENTS = 100; // 数组最大显示元素数量
         private const int MAX_OBJECT_PROPERTIES = 50; // 对象最大显示属性数量
 
-        public Logger(UnityModManager.ModEntry.ModLogger logger)
-        {
-            _logger = logger;
-        }
+        public Logger() { }
 
         // Log 支持多参数和对象展开
         public void Log(params object[] args)

--- a/frontline/Main.cs
+++ b/frontline/Main.cs
@@ -17,7 +17,7 @@ namespace Iridium
 
         private static string CurrentVersion => VersionManager.GetFullVersionString();
 
-        public static bool Load(dynamic modEntry)
+        public static bool Load(object modEntry)
         {
             return Initialize(new UmmHandler(modEntry));
         }

--- a/frontline/Main.cs
+++ b/frontline/Main.cs
@@ -1,14 +1,13 @@
 using System.Reflection;
 using HarmonyLib;
 using UnityEngine;
-using UnityModManagerNet;
 using Iridium.UI;
 
 namespace Iridium
 {
     public static class Main
     {
-        public static UnityModManager.ModEntry? Mod { get; private set; }
+        public static IHandler? Handler { get; private set; }
         public static Harmony? Harmony { get; private set; }
         public static Settings Settings { get; private set; } = null!;
         public static Logger? Logger;
@@ -16,25 +15,29 @@ namespace Iridium
 
         public static bool IsMainThread => System.Threading.Thread.CurrentThread.ManagedThreadId == _mainThreadId;
 
-        // 当前版本号（用于版本升级检测）
         private static string CurrentVersion => VersionManager.GetFullVersionString();
 
-        public static bool Load(UnityModManager.ModEntry modEntry)
+        public static bool Load(dynamic modEntry)
+        {
+            return Initialize(new UmmHandler(modEntry));
+        }
+
+        public static bool Initialize(IHandler handler)
         {
             _mainThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
-            Mod = modEntry;
-            Logger = new Logger(Mod.Logger);
-            Settings = UnityModManager.ModSettings.Load<Settings>(modEntry);
+            Handler = handler;
+            Logger = new Logger();
+            Settings = handler.LoadSettings<Settings>();
             Localization.Load();
 
-            modEntry.OnToggle = OnToggle;
-            modEntry.OnGUI = Main.Settings.OnGUI;
-            modEntry.OnSaveGUI = Main.Settings.Save;
-            modEntry.OnUpdate = OnUpdate;
+            handler.OnToggle += OnToggle;
+            handler.OnGUI += () => Settings.OnGUI();
+            handler.OnSaveGUI += () => handler.SaveSettings(Settings);
+            handler.OnUpdate += OnUpdate;
 
-            Harmony = new Harmony(modEntry.Info.Id);
+            Harmony = new Harmony(handler.ModId);
 
-            Logger?.Log(Localization.Get("ModLoaded", Main.Settings.language));
+            Logger?.Log(Localization.Get("ModLoaded", Settings.language));
             return true;
         }
 
@@ -51,7 +54,7 @@ namespace Iridium
             _destroyImmObj.Enqueue(obj);
         }
 
-        private static void OnUpdate(UnityModManager.ModEntry modEntry, float dt)
+        private static void OnUpdate(float dt)
         {
             while (_destroyImmObj.TryDequeue(out var obj))
             {
@@ -69,32 +72,26 @@ namespace Iridium
                 }
             }
             Logger.TaskRun();
-
         }
 
-        private static bool OnToggle(UnityModManager.ModEntry modEntry, bool value)
+        private static void OnToggle(bool value)
         {
             if (value)
             {
                 Logger?.Log(Localization.Get("ModEnabled"));
 
-                // 启动异步 Patch 管理器
                 Iridium.Patches.AsyncPatchManager.Start();
-
-                // Strategy: Load only what's needed (lazy loading)
                 Iridium.Patches.AsyncPatchManager.UpdateAllPatchesAsync();
 
                 if (Main.Settings.optimizer.enableOptimizer)
                 {
                     Iridium.Patches.OptimizerPatches.ResetDecorOptimization(true);
-                    // 如果DOTween优化已启用，应用设置
                     if (Main.Settings.optimizer.optimizeDOTweenGlobal)
                     {
                         Iridium.Patches.DOTweenOptimizationPatches.ApplyRuntimeSettings();
                     }
                 }
 
-                // 如果需要显示弹窗，使用 MainWindow
                 if (Main.Settings.firstRun)
                 {
                     UI.MainWindow.ShowFirstRun();
@@ -110,12 +107,9 @@ namespace Iridium
             {
                 Logger?.Log(Localization.Get("ModDisabled"));
 
-                // 停止异步 Patch 管理器
                 Iridium.Patches.AsyncPatchManager.Stop();
-
                 Iridium.Patches.PatchManager.UnpatchAll();
             }
-            return true;
         }
     }
 }

--- a/frontline/Patches/EditorFloorOptimizationPatches.cs
+++ b/frontline/Patches/EditorFloorOptimizationPatches.cs
@@ -573,6 +573,32 @@ namespace Iridium.Patches
 
         #endregion
 
+        #region Patch: Skip ApplyEventsToFloors during incremental insert
+
+        /// <summary>
+        /// 增量插入砖块时跳过全量 ApplyEventsToFloors。
+        /// OffsetFloorIDsInEvents 已经处理了事件 floor ID 偏移，
+        /// 全量重新应用事件对百万砖块是灾难性的。
+        /// </summary>
+        [HarmonyPatch(typeof(scnGame), "ApplyEventsToFloors",
+            new[] { typeof(List<scrFloor>) })]
+        public static class SkipApplyEventsOnInsertPatch
+        {
+            [HarmonyPrefix]
+            public static bool Prefix()
+            {
+                if (!Main.Settings.optimizer.enableEditorFloorOptimization) return true;
+                if (!_incrementalMode) return true;
+                if (!Main.Settings.optimizer.skipApplyEventsOnInsert) return true;
+
+                // Events already offset by OffsetFloorIDsInEvents / FloorWasCreatedOrDeleted.
+                // Skip the full re-application for massive level performance.
+                return false;
+            }
+        }
+
+        #endregion
+
         #region Utility
 
         public static void ResetState()

--- a/frontline/Patches/OptimizerPatches.cs
+++ b/frontline/Patches/OptimizerPatches.cs
@@ -13,7 +13,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Profiling;
-using UnityModManagerNet;
 
 namespace Iridium.Patches
 {

--- a/frontline/Patches/PatchManager.cs
+++ b/frontline/Patches/PatchManager.cs
@@ -107,8 +107,8 @@ namespace Iridium.Patches
                 () => editorMaster() && Main.Settings.optimizer.incrementalFloorInsert && Main.Settings.optimizer.skipRedundantRemakePath));
             _definitions.Add(new PatchDef(typeof(EditorFloorOptimizationPatches.OffsetFloorIDsOptimizationPatch),
                 () => editorMaster() && Main.Settings.optimizer.incrementalFloorInsert && Main.Settings.optimizer.optimizeOffsetFloorEvents));
-
-
+            _definitions.Add(new PatchDef(typeof(EditorFloorOptimizationPatches.SkipApplyEventsOnInsertPatch),
+                () => editorMaster() && Main.Settings.optimizer.incrementalFloorInsert && Main.Settings.optimizer.skipApplyEventsOnInsert));
 
             // --- Optimizer ---
             var optCond = () => Main.Settings.optimizer.enableOptimizer;

--- a/frontline/ResourceLoader.cs
+++ b/frontline/ResourceLoader.cs
@@ -10,8 +10,8 @@ namespace Iridium
         {
             get
             {
-                if (Main.Mod == null) throw new InvalidOperationException(Localization.Get("ModNotInitialized"));
-                return Path.Combine(Main.Mod.Path, "Resources");
+                if (Main.Handler == null) throw new InvalidOperationException(Localization.Get("ModNotInitialized"));
+                return Path.Combine(Main.Handler.ModPath, "Resources");
             }
         }
 

--- a/frontline/Settings.cs
+++ b/frontline/Settings.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityModManagerNet;
 using UnityEngine;
 using Iridium.UI;
 using Iridium.Config;
@@ -9,7 +8,7 @@ using static Iridium.UI.IridiumLayout;
 
 namespace Iridium
 {
-    public class Settings : UnityModManager.ModSettings
+    public class Settings
     {
         public string language = "en";
         public bool firstRun = true;
@@ -61,7 +60,7 @@ namespace Iridium
             return _cachedTabDisplayNames;
         }
 
-        public void OnGUI(UnityModManager.ModEntry modEntry)
+		public void OnGUI()
         {
             // Record initial stack depth for exception safety
             int initialStackDepth = IridiumLayout.ContainerStack.Count;
@@ -119,7 +118,7 @@ namespace Iridium
                 }
                 End();
 
-                if (GUI.changed) Save(modEntry);
+    			if (GUI.changed) Save();
             }
             catch (Exception ex)
             {
@@ -1149,9 +1148,9 @@ namespace Iridium
         }
         #endregion
 
-        public override void Save(UnityModManager.ModEntry modEntry)
-        {
-            Save(this, modEntry);
-        }
+		public void Save()
+		{
+			Main.Handler?.SaveSettings(this);
+		}
     }
 }

--- a/frontline/UI/IridiumLayout.cs
+++ b/frontline/UI/IridiumLayout.cs
@@ -6,7 +6,6 @@ using System.Drawing.Imaging;
 using System.Linq;
 using System.Runtime.InteropServices;
 using UnityEngine;
-using UnityModManagerNet;
 using Iridium.Utilities;
 using Color = UnityEngine.Color;
 using FontStyle = UnityEngine.FontStyle;
@@ -64,7 +63,7 @@ public static class IridiumLayout
     private static readonly Trigger<int, ResolutionResources> ResolutionTrigger = new();
 
     private static ResolutionResources Resolution => ResolutionTrigger.Get(
-        UnityModManager.UI.Scale(1048576),
+        (int)(Main.Handler?.UIScale ?? 1048576),
         scaleTimes1M => new ResolutionResources(scaleTimes1M)
     );
 

--- a/frontline/UI/MainWindow.cs
+++ b/frontline/UI/MainWindow.cs
@@ -194,7 +194,7 @@ namespace Iridium.UI
                             Main.Settings.firstRun = false;
                             Main.Settings.lastVersion = VersionManager.GetFullVersionString();
                             Main.Settings.lastUpgradeMessageSeen_106_beta5 = "1.0.6_beta5";
-                            if (Main.Mod != null) Main.Settings.Save(Main.Mod);
+                            Main.Handler?.SaveSettings(Main.Settings);
                         }
                     }
                 }
@@ -220,7 +220,7 @@ namespace Iridium.UI
                         {
                             Main.Settings.lastVersion = VersionManager.GetFullVersionString();
                             Main.Settings.lastUpgradeMessageSeen_106_beta5 = "1.0.6_beta5";
-                            if (Main.Mod != null) Main.Settings.Save(Main.Mod);
+                            Main.Handler?.SaveSettings(Main.Settings);
                         }
                     }
                 }

--- a/frontline/VersionManager.cs
+++ b/frontline/VersionManager.cs
@@ -18,7 +18,7 @@ namespace Iridium
 
         public static string GetFullVersionString()
         {
-            string baseVersion = Main.Mod?.Info.Version ?? "Error";
+            string baseVersion = Main.Handler?.ModVersion ?? "Error";
             string adofaiSuffix = $"+adofai{BuildInfo.AdofaiVersion}";
             if (Type == VersionType.Release)
             {

--- a/loaders/melonloader/Iridium.Loader.Melon.csproj
+++ b/loaders/melonloader/Iridium.Loader.Melon.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net481</TargetFramework>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Iridium</RootNamespace>
+		<AssemblyName>Iridium.Loader.Melon</AssemblyName>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<OutputPath>..\..\bin\loaders\melon\</OutputPath>
+		<AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="MelonLoader">
+			<HintPath>..\..\lib\ModManager\MelonLoader\net472\MelonLoader.dll</HintPath>
+		</Reference>
+		<Reference Include="0Harmony">
+			<HintPath>..\..\lib\ModManager\0Harmony.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine">
+			<HintPath>..\..\lib\v2.9.8\UnityEngine.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.CoreModule">
+			<HintPath>..\..\lib\v2.9.8\UnityEngine.CoreModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.IMGUIModule">
+			<HintPath>..\..\lib\v2.9.8\UnityEngine.IMGUIModule.dll</HintPath>
+		</Reference>
+		<ProjectReference Include="..\..\main\Iridium.csproj" />
+	</ItemGroup>
+</Project>

--- a/loaders/melonloader/Iridium.Loader.Melon.csproj
+++ b/loaders/melonloader/Iridium.Loader.Melon.csproj
@@ -26,6 +26,10 @@
 		<Reference Include="UnityEngine.IMGUIModule">
 			<HintPath>..\..\lib\v2.9.8\UnityEngine.IMGUIModule.dll</HintPath>
 		</Reference>
+		<Reference Include="Newtonsoft.Json">
+			<HintPath>..\..\lib\v2.9.8\Newtonsoft.Json.dll</HintPath>
+		</Reference>
+		<Reference Include="Microsoft.CSharp" />
 		<ProjectReference Include="..\..\main\Iridium.csproj" />
 	</ItemGroup>
 </Project>

--- a/loaders/melonloader/IridiumMelonMod.cs
+++ b/loaders/melonloader/IridiumMelonMod.cs
@@ -1,0 +1,28 @@
+using MelonLoader;
+
+[assembly: MelonInfo(typeof(Iridium.IridiumMelonMod), "Iridium", "1.3.0", "Xbodwf")]
+[assembly: MelonGame("7th Beat Games", "A Dance of Fire and Ice")]
+
+namespace Iridium
+{
+    public class IridiumMelonMod : MelonMod
+    {
+        private MelonHandler? _handler;
+
+        public override void OnInitializeMelon()
+        {
+            _handler = new MelonHandler(this);
+            Iridium.Main.Initialize(_handler);
+        }
+
+        public override void OnUpdate()
+        {
+            _handler?.TriggerUpdate(UnityEngine.Time.deltaTime);
+        }
+
+        public override void OnGUI()
+        {
+            _handler?.TriggerGUI();
+        }
+    }
+}

--- a/loaders/melonloader/MelonHandler.cs
+++ b/loaders/melonloader/MelonHandler.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using MelonLoader;
+
+namespace Iridium
+{
+    public class MelonHandler : IHandler
+    {
+        private readonly IridiumMelonMod _mod;
+        private readonly string _modPath;
+
+        public MelonHandler(IridiumMelonMod mod)
+        {
+            _mod = mod;
+            _modPath = Path.Combine(
+                Path.GetDirectoryName(mod.MelonAssembly.Location) ?? ".",
+                "Iridium"
+            );
+            Directory.CreateDirectory(_modPath);
+        }
+
+        public string ModId => _mod.Info.Name;
+        public string ModVersion => _mod.Info.Version;
+        public string ModPath => _modPath;
+
+        public void Log(string message) => MelonLogger.Msg(message);
+        public void Warning(string message) => MelonLogger.Warning(message);
+        public void Error(string message) => MelonLogger.Error(message);
+
+        public T LoadSettings<T>() where T : class, new()
+        {
+            string settingsPath = Path.Combine(_modPath, "Settings.xml");
+            if (File.Exists(settingsPath))
+            {
+                try
+                {
+                    var serializer = new XmlSerializer(typeof(T));
+                    using var reader = new StreamReader(settingsPath);
+                    return (T)(serializer.Deserialize(reader) ?? new T());
+                }
+                catch
+                {
+                    return new T();
+                }
+            }
+            return new T();
+        }
+
+        public void SaveSettings<T>(T settings) where T : class
+        {
+            string settingsPath = Path.Combine(_modPath, "Settings.xml");
+            try
+            {
+                var serializer = new XmlSerializer(typeof(T));
+                using var writer = new StreamWriter(settingsPath);
+                serializer.Serialize(writer, settings);
+            }
+            catch (Exception ex)
+            {
+                Log($"Failed to save settings: {ex.Message}");
+            }
+        }
+
+        public float UIScale => 1048576;
+
+        public event Action<float>? OnUpdate;
+        public event Action<bool>? OnToggle;
+        public event Action? OnGUI;
+        public event Action? OnSaveGUI;
+
+        public void TriggerUpdate(float dt) => OnUpdate?.Invoke(dt);
+        public void TriggerGUI() => OnGUI?.Invoke();
+    }
+}

--- a/loaders/melonloader/MelonHandler.cs
+++ b/loaders/melonloader/MelonHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 using MelonLoader;
 
 namespace Iridium
@@ -9,19 +10,30 @@ namespace Iridium
     {
         private readonly IridiumMelonMod _mod;
         private readonly string _modPath;
+        private readonly Lazy<string> _modVersion;
 
         public MelonHandler(IridiumMelonMod mod)
         {
             _mod = mod;
-            _modPath = Path.Combine(
-                Path.GetDirectoryName(mod.MelonAssembly.Location) ?? ".",
-                "Iridium"
-            );
-            Directory.CreateDirectory(_modPath);
+            _modPath = Path.GetDirectoryName(mod.MelonAssembly.Location) ?? ".";
+            _modVersion = new Lazy<string>(() =>
+            {
+                string infoPath = Path.Combine(_modPath, "Info.json");
+                try
+                {
+                    var json = File.ReadAllText(infoPath);
+                    dynamic? info = JsonConvert.DeserializeObject(json);
+                    return (string)(info?.Version ?? "Error");
+                }
+                catch
+                {
+                    return "Error";
+                }
+            });
         }
 
         public string ModId => _mod.Info.Name;
-        public string ModVersion => _mod.Info.Version;
+        public string ModVersion => _modVersion.Value;
         public string ModPath => _modPath;
 
         public void Log(string message) => MelonLogger.Msg(message);

--- a/loaders/ummloader/IHandler.cs
+++ b/loaders/ummloader/IHandler.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Iridium
+{
+    public interface IHandler
+    {
+        string ModId { get; }
+        string ModVersion { get; }
+        string ModPath { get; }
+
+        void Log(string message);
+        void Warning(string message);
+        void Error(string message);
+
+        T LoadSettings<T>() where T : class, new();
+        void SaveSettings<T>(T settings) where T : class;
+
+        float UIScale { get; }
+
+        event Action<float> OnUpdate;
+        event Action<bool> OnToggle;
+        event Action OnGUI;
+        event Action OnSaveGUI;
+    }
+}

--- a/loaders/ummloader/Iridium.Loader.UMM.csproj
+++ b/loaders/ummloader/Iridium.Loader.UMM.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net481</TargetFramework>
+		<OutputType>Library</OutputType>
+		<RootNamespace>Iridium.Loader</RootNamespace>
+		<AssemblyName>Iridium.Loader.UMM</AssemblyName>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<OutputPath>..\..\bin\loaders\umm\</OutputPath>
+		<AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="UnityModManager">
+			<HintPath>..\..\lib\ModManager\UnityModManager.dll</HintPath>
+		</Reference>
+		<Reference Include="0Harmony">
+			<HintPath>..\..\lib\ModManager\0Harmony.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine">
+			<HintPath>..\..\lib\v2.9.8\UnityEngine.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.CoreModule">
+			<HintPath>..\..\lib\v2.9.8\UnityEngine.CoreModule.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+</Project>

--- a/loaders/ummloader/UmmHandler.cs
+++ b/loaders/ummloader/UmmHandler.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using UnityModManagerNet;
+
+namespace Iridium
+{
+    public class UmmHandler : IHandler
+    {
+        private readonly UnityModManager.ModEntry _entry;
+
+        public UmmHandler(object entry)
+        {
+            _entry = (UnityModManager.ModEntry)entry;
+            _entry.OnUpdate = (_, dt) => OnUpdate?.Invoke(dt);
+            _entry.OnToggle = (_, v) => { OnToggle?.Invoke(v); return true; };
+            _entry.OnGUI = _ => OnGUI?.Invoke();
+            _entry.OnSaveGUI = _ => OnSaveGUI?.Invoke();
+        }
+
+        public string ModId => _entry.Info.Id;
+        public string ModVersion => _entry.Info.Version;
+        public string ModPath => _entry.Path;
+
+        public void Log(string message) => _entry.Logger.Log(message);
+        public void Warning(string message) => _entry.Logger.Warning(message);
+        public void Error(string message) => _entry.Logger.Error(message);
+
+        public T LoadSettings<T>() where T : class, new()
+        {
+            string settingsPath = Path.Combine(_entry.Path, "Settings.xml");
+            if (File.Exists(settingsPath))
+            {
+                try
+                {
+                    var serializer = new XmlSerializer(typeof(T));
+                    using var reader = new StreamReader(settingsPath);
+                    return (T)(serializer.Deserialize(reader) ?? new T());
+                }
+                catch
+                {
+                    return new T();
+                }
+            }
+            return new T();
+        }
+
+        public void SaveSettings<T>(T settings) where T : class
+        {
+            string settingsPath = Path.Combine(_entry.Path, "Settings.xml");
+            try
+            {
+                var serializer = new XmlSerializer(typeof(T));
+                using var writer = new StreamWriter(settingsPath);
+                serializer.Serialize(writer, settings);
+            }
+            catch (Exception ex)
+            {
+                Log($"Failed to save settings: {ex.Message}");
+            }
+        }
+
+        public float UIScale => UnityModManager.UI.Scale(1048576);
+
+        public event Action<float>? OnUpdate;
+        public event Action<bool>? OnToggle;
+        public event Action? OnGUI;
+        public event Action? OnSaveGUI;
+    }
+}

--- a/main/Config/SubSettings.cs
+++ b/main/Config/SubSettings.cs
@@ -68,6 +68,7 @@ namespace Iridium.Config
         public bool rangeBasedRedraw = false;              // 范围式重绘(Holds/Planets/Nums)
         public bool skipRedundantRemakePath = false;       // 跳过重复的RemakePath调用
         public bool optimizeOffsetFloorEvents = false;     // 优化 OffsetFloorIDsInEvents
+        public bool skipApplyEventsOnInsert = false;       // 增量插入时跳过 ApplyEventsToFloors
     }
 
     public class UISettings

--- a/main/Iridium.csproj
+++ b/main/Iridium.csproj
@@ -282,7 +282,6 @@
 		<Reference Include="UnityEngine.XRModule">
 			<HintPath>..\lib\v2.9.8\UnityEngine.XRModule.dll</HintPath>
 		</Reference>
-		<Reference Include="Microsoft.CSharp" />
 		<ProjectReference Include="..\loaders\ummloader\Iridium.Loader.UMM.csproj">
 			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
 		</ProjectReference>

--- a/main/Iridium.csproj
+++ b/main/Iridium.csproj
@@ -282,9 +282,10 @@
 		<Reference Include="UnityEngine.XRModule">
 			<HintPath>..\lib\v2.9.8\UnityEngine.XRModule.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityModManager">
-			<HintPath>..\lib\ModManager\UnityModManager.dll</HintPath>
-		</Reference>
+		<Reference Include="Microsoft.CSharp" />
+		<ProjectReference Include="..\loaders\ummloader\Iridium.Loader.UMM.csproj">
+			<ReferenceOutputAssembly>true</ReferenceOutputAssembly>
+		</ProjectReference>
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="Info.json">
@@ -305,6 +306,7 @@
 		<MakeDir Directories="$(OutDir)Resources" />
 		<ItemGroup>
 			<FilesToCopy Include="$(OutputPath)$(AssemblyName).dll" />
+			<FilesToCopy Include="$(ProjectDir)..\bin\loaders\umm\net481\Iridium.Loader.UMM.dll" />
 			<FilesToCopy Include="$(ProjectDir)Info.json" />
 			<ResourceFiles Include="$(ProjectDir)Resources\**\*" Exclude="$(ProjectDir)Resources\**\*\" />
 		</ItemGroup>

--- a/main/Iridium.csproj
+++ b/main/Iridium.csproj
@@ -307,6 +307,7 @@
 		<ItemGroup>
 			<FilesToCopy Include="$(OutputPath)$(AssemblyName).dll" />
 			<FilesToCopy Include="$(ProjectDir)..\bin\loaders\umm\net481\Iridium.Loader.UMM.dll" />
+			<FilesToCopy Include="$(ProjectDir)..\bin\loaders\melon\net481\Iridium.Loader.Melon.dll" />
 			<FilesToCopy Include="$(ProjectDir)Info.json" />
 			<ResourceFiles Include="$(ProjectDir)Resources\**\*" Exclude="$(ProjectDir)Resources\**\*\" />
 		</ItemGroup>

--- a/main/Logger.cs
+++ b/main/Logger.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using UnityModManagerNet;
 
 
 namespace Iridium
@@ -36,13 +35,8 @@ namespace Iridium
         private const string MODNAME_ERROR = "[Iridium/ERROR] "; // Prefix Name
         private static readonly ConcurrentQueue<LogData> _writeQueue = new();
         private static Task? _task;
-        private static readonly List<string> _history = (List<string>)
-                typeof(UnityModManager.Logger).GetField("history", HarmonyLib.AccessTools.all).GetValue(null);
-        private static readonly int _historyCapacity = (int)
-                typeof(UnityModManager.Logger).GetField("historyCapacity", HarmonyLib.AccessTools.all).GetValue(null);
-        // 不写入buffer 减少性能消耗 (因为这玩意tm是主线程做IO写入的)
-        // private static unsafe readonly List<string> _buffer = (List<string>)
-        //         typeof(UnityModManager.Logger).GetField("buffer", HarmonyLib.AccessTools.all).GetValue(null);
+        private static readonly List<string> _history = new();
+        private const int _historyCapacity = 500;
 #if UNSAFE_MODE
         public static void TaskRun()
         {
@@ -142,8 +136,6 @@ namespace Iridium
 
 #endif
 
-        private readonly UnityModManager.ModEntry.ModLogger _logger;
-
         // 定义颜色常量
         private const string COLOR_RESET = "</color>";
         private const string COLOR_KEYWORD = "<color=#569CD6>"; // 例如：class, struct
@@ -163,10 +155,7 @@ namespace Iridium
         private const int MAX_ARRAY_ELEMENTS = 100; // 数组最大显示元素数量
         private const int MAX_OBJECT_PROPERTIES = 50; // 对象最大显示属性数量
 
-        public Logger(UnityModManager.ModEntry.ModLogger logger)
-        {
-            _logger = logger;
-        }
+        public Logger() { }
 
         // Log 支持多参数和对象展开
         public void Log(params object[] args)

--- a/main/Main.cs
+++ b/main/Main.cs
@@ -1,14 +1,13 @@
 using System.Reflection;
 using HarmonyLib;
 using UnityEngine;
-using UnityModManagerNet;
 using Iridium.UI;
 
 namespace Iridium
 {
     public static class Main
     {
-        public static UnityModManager.ModEntry? Mod { get; private set; }
+        public static IHandler? Handler { get; private set; }
         public static Harmony? Harmony { get; private set; }
         public static Settings Settings { get; private set; } = null!;
         public static Logger? Logger;
@@ -19,22 +18,27 @@ namespace Iridium
         // 当前版本号（用于版本升级检测）
         private static string CurrentVersion => VersionManager.GetFullVersionString();
 
-        public static bool Load(UnityModManager.ModEntry modEntry)
+        public static bool Load(dynamic modEntry)
+        {
+            return Initialize(new UmmHandler(modEntry));
+        }
+
+        public static bool Initialize(IHandler handler)
         {
             _mainThreadId = System.Threading.Thread.CurrentThread.ManagedThreadId;
-            Mod = modEntry;
-            Logger = new Logger(Mod.Logger);
-            Settings = UnityModManager.ModSettings.Load<Settings>(modEntry);
+            Handler = handler;
+            Logger = new Logger();
+            Settings = handler.LoadSettings<Settings>();
             Localization.Load();
 
-            modEntry.OnToggle = OnToggle;
-            modEntry.OnGUI = Main.Settings.OnGUI;
-            modEntry.OnSaveGUI = Main.Settings.Save;
-            modEntry.OnUpdate = OnUpdate;
+            handler.OnToggle += OnToggle;
+            handler.OnGUI += () => Settings.OnGUI();
+            handler.OnSaveGUI += () => handler.SaveSettings(Settings);
+            handler.OnUpdate += OnUpdate;
 
-            Harmony = new Harmony(modEntry.Info.Id);
+            Harmony = new Harmony(handler.ModId);
 
-            Logger?.Log(Localization.Get("ModLoaded", Main.Settings.language));
+            Logger?.Log(Localization.Get("ModLoaded", Settings.language));
             return true;
         }
 
@@ -51,7 +55,7 @@ namespace Iridium
             _destroyImmObj.Enqueue(obj);
         }
 
-        private static void OnUpdate(UnityModManager.ModEntry modEntry, float dt)
+        private static void OnUpdate(float dt)
         {
             while (_destroyImmObj.TryDequeue(out var obj))
             {
@@ -71,7 +75,7 @@ namespace Iridium
             Logger.TaskRun();
         }
 
-        private static bool OnToggle(UnityModManager.ModEntry modEntry, bool value)
+        private static void OnToggle(bool value)
         {
             if (value)
             {
@@ -114,7 +118,6 @@ namespace Iridium
 
                 Iridium.Patches.PatchManager.UnpatchAll();
             }
-            return true;
         }
     }
 }

--- a/main/Main.cs
+++ b/main/Main.cs
@@ -15,10 +15,9 @@ namespace Iridium
 
         public static bool IsMainThread => System.Threading.Thread.CurrentThread.ManagedThreadId == _mainThreadId;
 
-        // 当前版本号（用于版本升级检测）
         private static string CurrentVersion => VersionManager.GetFullVersionString();
 
-        public static bool Load(dynamic modEntry)
+        public static bool Load(object modEntry)
         {
             return Initialize(new UmmHandler(modEntry));
         }
@@ -81,23 +80,18 @@ namespace Iridium
             {
                 Logger?.Log(Localization.Get("ModEnabled"));
 
-                // 启动异步 Patch 管理器
                 Iridium.Patches.AsyncPatchManager.Start();
-
-                // Strategy: Load only what's needed (lazy loading)
                 Iridium.Patches.AsyncPatchManager.UpdateAllPatchesAsync();
 
                 if (Main.Settings.optimizer.enableOptimizer)
                 {
                     Iridium.Patches.OptimizerPatches.ResetDecorOptimization(true);
-                    // 如果DOTween优化已启用，应用设置
                     if (Main.Settings.optimizer.optimizeDOTweenGlobal)
                     {
                         Iridium.Patches.DOTweenOptimizationPatches.ApplyRuntimeSettings();
                     }
                 }
 
-                // 如果需要显示弹窗，使用 MainWindow
                 if (Main.Settings.firstRun)
                 {
                     UI.MainWindow.ShowFirstRun();
@@ -113,9 +107,7 @@ namespace Iridium
             {
                 Logger?.Log(Localization.Get("ModDisabled"));
 
-                // 停止异步 Patch 管理器
                 Iridium.Patches.AsyncPatchManager.Stop();
-
                 Iridium.Patches.PatchManager.UnpatchAll();
             }
         }

--- a/main/Patches/EditorFloorOptimizationPatches.cs
+++ b/main/Patches/EditorFloorOptimizationPatches.cs
@@ -573,6 +573,32 @@ namespace Iridium.Patches
 
         #endregion
 
+        #region Patch: Skip ApplyEventsToFloors during incremental insert
+
+        /// <summary>
+        /// 增量插入砖块时跳过全量 ApplyEventsToFloors。
+        /// OffsetFloorIDsInEvents 已经处理了事件 floor ID 偏移，
+        /// 全量重新应用事件对百万砖块是灾难性的。
+        /// </summary>
+        [HarmonyPatch(typeof(scnGame), "ApplyEventsToFloors",
+            new[] { typeof(List<scrFloor>) })]
+        public static class SkipApplyEventsOnInsertPatch
+        {
+            [HarmonyPrefix]
+            public static bool Prefix()
+            {
+                if (!Main.Settings.optimizer.enableEditorFloorOptimization) return true;
+                if (!_incrementalMode) return true;
+                if (!Main.Settings.optimizer.skipApplyEventsOnInsert) return true;
+
+                // Events already offset by OffsetFloorIDsInEvents / FloorWasCreatedOrDeleted.
+                // Skip the full re-application for massive level performance.
+                return false;
+            }
+        }
+
+        #endregion
+
         #region Utility
 
         public static void ResetState()

--- a/main/Patches/OptimizerPatches.cs
+++ b/main/Patches/OptimizerPatches.cs
@@ -13,7 +13,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Profiling;
-using UnityModManagerNet;
 
 namespace Iridium.Patches
 {

--- a/main/Patches/PatchManager.cs
+++ b/main/Patches/PatchManager.cs
@@ -144,6 +144,8 @@ namespace Iridium.Patches
                 () => editorMaster() && Main.Settings.optimizer.incrementalFloorInsert && Main.Settings.optimizer.skipRedundantRemakePath));
             _definitions.Add(new PatchDef(typeof(EditorFloorOptimizationPatches.OffsetFloorIDsOptimizationPatch),
                 () => editorMaster() && Main.Settings.optimizer.incrementalFloorInsert && Main.Settings.optimizer.optimizeOffsetFloorEvents));
+            _definitions.Add(new PatchDef(typeof(EditorFloorOptimizationPatches.SkipApplyEventsOnInsertPatch),
+                () => editorMaster() && Main.Settings.optimizer.incrementalFloorInsert && Main.Settings.optimizer.skipApplyEventsOnInsert));
 
             // --- UI / Misc ---
             _definitions.Add(new PatchDef(typeof(MiscPatches.RemoveNewsPatch), () => Main.Settings.ui.removeNews));

--- a/main/ResourceLoader.cs
+++ b/main/ResourceLoader.cs
@@ -10,8 +10,8 @@ namespace Iridium
         {
             get
             {
-                if (Main.Mod == null) throw new InvalidOperationException(Localization.Get("ModNotInitialized"));
-                return Path.Combine(Main.Mod.Path, "Resources");
+                if (Main.Handler == null) throw new InvalidOperationException(Localization.Get("ModNotInitialized"));
+                return Path.Combine(Main.Handler.ModPath, "Resources");
             }
         }
 

--- a/main/Settings.cs
+++ b/main/Settings.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityModManagerNet;
 using UnityEngine;
 using Iridium.UI;
 using Iridium.Config;
@@ -9,7 +8,7 @@ using static Iridium.UI.IridiumLayout;
 
 namespace Iridium
 {
-    public class Settings : UnityModManager.ModSettings
+    public class Settings
     {
         public string language = "en";
         public bool firstRun = true;
@@ -59,7 +58,7 @@ namespace Iridium
             return _cachedTabDisplayNames;
         }
 
-        public void OnGUI(UnityModManager.ModEntry modEntry)
+		public void OnGUI()
         {
             // Record initial stack depth for exception safety
             int initialStackDepth = IridiumLayout.ContainerStack.Count;
@@ -117,7 +116,7 @@ namespace Iridium
                 }
                 End();
 
-                if (GUI.changed) Save(modEntry);
+    			if (GUI.changed) Save();
             }
             catch (Exception ex)
             {
@@ -1022,9 +1021,9 @@ AsyncPatchManager.UpdatePatchByTypeAsync(typeof(CompatibilityPatches.LegacyPause
         }
         #endregion
 
-        public override void Save(UnityModManager.ModEntry modEntry)
-        {
-            Save(this, modEntry);
-        }
+		public void Save()
+		{
+			Main.Handler?.SaveSettings(this);
+		}
     }
 }

--- a/main/UI/IridiumLayout.cs
+++ b/main/UI/IridiumLayout.cs
@@ -6,7 +6,6 @@ using System.Drawing.Imaging;
 using System.Linq;
 using System.Runtime.InteropServices;
 using UnityEngine;
-using UnityModManagerNet;
 using Iridium.Utilities;
 using Color = UnityEngine.Color;
 using FontStyle = UnityEngine.FontStyle;
@@ -64,7 +63,7 @@ public static class IridiumLayout
     private static readonly Trigger<int, ResolutionResources> ResolutionTrigger = new();
 
     private static ResolutionResources Resolution => ResolutionTrigger.Get(
-        UnityModManager.UI.Scale(1048576),
+        (int)(Main.Handler?.UIScale ?? 1048576),
         scaleTimes1M => new ResolutionResources(scaleTimes1M)
     );
 

--- a/main/UI/MainWindow.cs
+++ b/main/UI/MainWindow.cs
@@ -194,7 +194,7 @@ namespace Iridium.UI
                             Main.Settings.firstRun = false;
                             Main.Settings.lastVersion = VersionManager.GetFullVersionString();
                             Main.Settings.lastUpgradeMessageSeen_106_beta5 = "1.0.6_beta5";
-                            if (Main.Mod != null) Main.Settings.Save(Main.Mod);
+                            Main.Handler?.SaveSettings(Main.Settings);
                         }
                     }
                 }
@@ -220,7 +220,7 @@ namespace Iridium.UI
                         {
                             Main.Settings.lastVersion = VersionManager.GetFullVersionString();
                             Main.Settings.lastUpgradeMessageSeen_106_beta5 = "1.0.6_beta5";
-                            if (Main.Mod != null) Main.Settings.Save(Main.Mod);
+                            Main.Handler?.SaveSettings(Main.Settings);
                         }
                     }
                 }

--- a/main/VersionManager.cs
+++ b/main/VersionManager.cs
@@ -18,7 +18,7 @@ namespace Iridium
 
         public static string GetFullVersionString()
         {
-            string baseVersion = Main.Mod?.Info.Version ?? "Error";
+            string baseVersion = Main.Handler?.ModVersion ?? "Error";
             string adofaiSuffix = $"+adofai{BuildInfo.AdofaiVersion}";
             if (Type == VersionType.Release)
             {

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a loader abstraction to support multiple mod loaders and add an editor performance optimization option.

New Features:
- Add a generic handler interface and concrete implementations for UnityModManager and MelonLoader, enabling Iridium to run under multiple loaders.
- Add a MelonLoader bootstrap mod to initialize Iridium via the new handler abstraction.
- Expose a new optimizer setting to optionally skip expensive ApplyEventsToFloors calls during incremental floor insertion for large levels.

Enhancements:
- Decouple core logic, settings, logging, versioning, and resource loading from UnityModManager-specific APIs by routing them through the new handler interface.
- Update UI layout scaling and settings persistence to work through the loader abstraction instead of direct UnityModManager calls.

Build:
- Add new loader-specific projects and shared build configuration files to structure multi-loader support.