### PR TITLE
fix: update LockInput patch target for v2.10.0 compat

### DIFF
--- a/frontline/Logger.cs
+++ b/frontline/Logger.cs
@@ -40,8 +40,8 @@ namespace Iridium
 #if UNSAFE_MODE
         public static void TaskRun()
         {
-            if (_task != null && !_task.Wait(1000))
-                throw new Exception("thread can't stop");
+            if (_task != null && !_task.IsCompleted)
+                return;
             _task = Task.Run(ThreadTask);
         }
         private static void ThreadTask()

--- a/frontline/Patches/BugfixPatches.cs
+++ b/frontline/Patches/BugfixPatches.cs
@@ -135,7 +135,7 @@ namespace Iridium.Patches
         ///   2) HandlePause Postfix — detects pause events, stores per-player state
         ///   3) scrPlayer.Hit Prefix — coop mode checks per-player pause state
         /// </summary>
-        [HarmonyPatch(typeof(scrController), nameof(scrController.LockInput))]
+        [HarmonyPatch(typeof(scrPlayer), nameof(scrPlayer.LockInput))]
         public static class CoopPauseLockFix
         {
             internal static readonly Dictionary<int, float> _playerPauseEndTimes = new();


### PR DESCRIPTION
## Summary by Sourcery

Adjust cooperative pause handling patch target for updated game API and relax logger task restart behavior.

Bug Fixes:
- Update the cooperative pause LockInput Harmony patch to target scrPlayer for compatibility with the latest game version.
- Prevent logger task restarts from throwing when an existing background task does not stop promptly by only starting a new task when the previous one has completed.