### PR TITLE
fix: add nuget.org source for CI build

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update nuget.config to add nuget.org as a package source for CI builds.